### PR TITLE
Expose admin login via dedicated /admin route

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -p 8080:8080 -e ADMIN_PASSWORD=admin123 attendance-app
 
 ## Usage
 
-1. Log in using the password.
+1. Visit `/admin` and log in using the password.
 2. Create a group with start and end dates.
 3. Add students and class days.
 4. Record attendance and view scores or download the CSV export.

--- a/auth.py
+++ b/auth.py
@@ -17,6 +17,11 @@ def login_required(view):
     return wrapped
 
 
+@auth_bp.route("/admin")
+def admin():
+    return redirect(url_for("auth.login"))
+
+
 @auth_bp.route("/login", methods=["GET", "POST"])
 def login():
     form = LoginForm()

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
   <h1>Welcome to LtcLabDM</h1>
   <p>This is the initial landing page.</p>
+  <p><a href="/admin">Admin Login</a></p>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,6 +15,8 @@
           {{ csrf_token() }}
           <button class="btn btn-outline-danger" type="submit">Logout</button>
         </form>
+        {% else %}
+        <a class="btn btn-outline-primary" href="{{ url_for('auth.admin') }}">Admin Login</a>
         {% endif %}
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- Add /admin route redirecting to login
- Include Admin Login link in navbar and landing page
- Document admin login URL in README

## Testing
- `pytest` *(fails: No module named 'app')*
- `pip install flask_sqlalchemy` *(fails: Could not find a version due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adae0b290c8332912917bab6bfd355